### PR TITLE
Add built-in API documentation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.sletmoe.bucket4k:bucket4k:1.0.0")
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 }

--- a/src/main/kotlin/app/umcu/api/ApiApplication.kt
+++ b/src/main/kotlin/app/umcu/api/ApiApplication.kt
@@ -27,9 +27,22 @@
 
 package app.umcu.api
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition
+import io.swagger.v3.oas.annotations.info.Contact
+import io.swagger.v3.oas.annotations.info.Info
+import io.swagger.v3.oas.annotations.info.License
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 
+@OpenAPIDefinition(
+	info = Info(
+		title = "UMCU API",
+		version = "1.0",
+		summary = "The ultimate source for staying up-to-date with the MCU.",
+		contact = Contact(name = "UMCU", email = "api@umcu.app", url = "https://github.com/upcomingmcu"),
+		license = License(name = "Unlicense", url = "https://choosealicense.com/licenses/unlicense/")
+	)
+)
 @SpringBootApplication
 class ApiApplication
 

--- a/src/main/kotlin/app/umcu/api/features/error/ErrorHandlerController.kt
+++ b/src/main/kotlin/app/umcu/api/features/error/ErrorHandlerController.kt
@@ -29,6 +29,7 @@
 
 package app.umcu.api.features.error
 
+import io.swagger.v3.oas.annotations.Hidden
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.boot.web.servlet.error.ErrorController
@@ -37,6 +38,7 @@ import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.ResponseBody
 
+@Hidden
 @Controller
 class ErrorHandlerController : ErrorController {
 

--- a/src/main/kotlin/app/umcu/api/features/productions/controller/ProductionsController.kt
+++ b/src/main/kotlin/app/umcu/api/features/productions/controller/ProductionsController.kt
@@ -29,10 +29,19 @@
 
 package app.umcu.api.features.productions.controller
 
+import app.umcu.api.features.error.Error
 import app.umcu.api.features.productions.model.Production
 import app.umcu.api.features.productions.service.ProductionsService
 import com.sletmoe.bucket4k.SuspendingBucket
 import io.github.bucket4j.Bandwidth
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.*
@@ -40,13 +49,30 @@ import org.springframework.web.server.ResponseStatusException
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.toJavaDuration
 
+@Tag(name = "Productions", description = "Browse through all released, upcoming, and announced productions.")
 @RestController
-@RequestMapping(path = ["/productions", "/p"], method = [RequestMethod.GET])
+@RequestMapping(
+	path = ["/productions"], method = [RequestMethod.GET], produces = ["application/json"]
+)
 class ProductionsController(val productionsService: ProductionsService) {
 	private val bucket = SuspendingBucket.build {
 		addLimit(Bandwidth.simple(60, 1.minutes.toJavaDuration()))
 	}
 
+	@Operation(summary = "Get all released, upcoming, and announced productions.")
+	@ApiResponses(
+		value = [ApiResponse(
+			responseCode = "200", description = "Productions found.", content = [Content(
+				mediaType = "application/json", array = ArraySchema(
+					schema = Schema(implementation = Production::class)
+				)
+			)]
+		), ApiResponse(
+			responseCode = "429", description = "Rate limit exceeded.", content = [Content(
+				mediaType = "application/json", schema = Schema(implementation = Error::class)
+			)]
+		)]
+	)
 	@GetMapping
 	fun findAllProductions(): List<Production> {
 		if (bucket.tryConsume(1)) {
@@ -56,8 +82,28 @@ class ProductionsController(val productionsService: ProductionsService) {
 		}
 	}
 
+	@Operation(summary = "Get a specific production.")
+	@ApiResponses(
+		value = [ApiResponse(
+			responseCode = "200", description = "Production found.", content = [Content(
+				mediaType = "application/json", schema = Schema(implementation = Production::class)
+			)]
+		), ApiResponse(
+			responseCode = "404", description = "Production not found.", content = [Content(
+				mediaType = "application/json", schema = Schema(implementation = Error::class)
+			)]
+		), ApiResponse(
+			responseCode = "429", description = "Rate limit exceeded.", content = [Content(
+				mediaType = "application/json", schema = Schema(implementation = Error::class)
+			)]
+		)]
+	)
 	@GetMapping("/{slug}")
-	fun findProductionBySlug(@PathVariable slug: String): Production? {
+	fun findProductionBySlug(
+		@Parameter(
+			required = true, description = "A production's slug.", example = "iron-man"
+		) @PathVariable slug: String
+	): Production? {
 		if (bucket.tryConsume(1)) {
 			return productionsService.findProductionBySlug(slug)
 		} else {
@@ -65,9 +111,29 @@ class ProductionsController(val productionsService: ProductionsService) {
 		}
 	}
 
+	@Operation(summary = "Get the next production to be released.")
+	@ApiResponses(
+		value = [ApiResponse(
+			responseCode = "200", description = "Upcoming production found.", content = [Content(
+				mediaType = "application/json", schema = Schema(implementation = Production::class)
+			)]
+		), ApiResponse(
+			responseCode = "404", description = "No further productions.", content = [Content(
+				mediaType = "application/json", schema = Schema(implementation = Error::class)
+			)]
+		), ApiResponse(
+			responseCode = "429", description = "Rate limit exceeded.", content = [Content(
+				mediaType = "application/json", schema = Schema(implementation = Error::class)
+			)]
+		)]
+	)
 	@GetMapping("/next")
 	fun findNextProduction(
-		@RequestParam(required = false) date: String? = null, httpServletResponse: HttpServletResponse
+		@Parameter(
+			required = false,
+			description = "Find the next production after the date. In the format of \"YYYY-MM-DD\".",
+			example = "2008-05-02"
+		) @RequestParam(required = false) date: String? = null, httpServletResponse: HttpServletResponse
 	) {
 		if (bucket.tryConsume(1)) {
 			val next =

--- a/src/main/kotlin/app/umcu/api/features/productions/repository/ProductionsRepository.kt
+++ b/src/main/kotlin/app/umcu/api/features/productions/repository/ProductionsRepository.kt
@@ -28,8 +28,10 @@
 package app.umcu.api.features.productions.repository
 
 import app.umcu.api.features.productions.model.Production
+import io.swagger.v3.oas.annotations.Hidden
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
+@Hidden
 @Repository
 interface ProductionsRepository : JpaRepository<Production, String> {}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+# suppress inspection "SpellCheckingInspection" for whole file
 # suppress inspection "UnusedProperty" for whole file
 logging.file.path=./
 spring.datasource.url=jdbc:postgresql://db:5432/${POSTGRES_USER}
@@ -7,3 +8,4 @@ spring.jpa.hibernate.ddl-auto=create-drop
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect
 spring.jpa.properties.hibernate.format_sql=true
+springdoc.swagger-ui.operationsSorter=method


### PR DESCRIPTION
As referenced in #9. These changes set up internal API documentation through the use of [springdoc-openapi v2.2.0](https://springdoc.org/). The documentation can be accessed at the path "/swagger-ui/index.html" (with a goal of updating this to be "/docs"). Furthermore, annotations are set up for all relevant models, controllers, repositories, etc. to properly map out the document the API.