### PR TITLE
Create mediaType property for Production entity

### DIFF
--- a/src/main/kotlin/app/umcu/api/features/productions/model/Production.kt
+++ b/src/main/kotlin/app/umcu/api/features/productions/model/Production.kt
@@ -40,5 +40,10 @@ data class Production(
 	@Column(columnDefinition = "TEXT", nullable = true) var overview: String? = null,
 	@Column(nullable = true) var releaseDate: LocalDate? = null,
 	@Column(nullable = true) var poster: String? = null,
+	@Column(nullable = true) var mediaType: MediaType? = null,
 	@Id @Column(nullable = false) val slug: String? = title?.toSlug()
-)
+) {
+	enum class MediaType {
+		MOVIE, TV
+	}
+}

--- a/src/main/kotlin/app/umcu/api/features/productions/model/Production.kt
+++ b/src/main/kotlin/app/umcu/api/features/productions/model/Production.kt
@@ -40,7 +40,7 @@ data class Production(
 	@Column(columnDefinition = "TEXT", nullable = true) var overview: String? = null,
 	@Column(nullable = true) var releaseDate: LocalDate? = null,
 	@Column(nullable = true) var poster: String? = null,
-	@Column(nullable = true) var mediaType: MediaType? = null,
+	@Column(nullable = true) @Enumerated(EnumType.STRING) var mediaType: MediaType? = null,
 	@Id @Column(nullable = false) val slug: String? = title?.toSlug()
 ) {
 	enum class MediaType {

--- a/src/main/kotlin/app/umcu/api/remote/TMDBService.kt
+++ b/src/main/kotlin/app/umcu/api/remote/TMDBService.kt
@@ -130,6 +130,7 @@ class TMDBService(
 					title = movieDetails.title,
 					overview = movieDetails.overview,
 					releaseDate = parsedReleaseDate,
+					mediaType = Production.MediaType.MOVIE,
 					poster = getPosterUrl(movieDetails.posterPath)
 				)
 				productions.add(production)
@@ -153,6 +154,7 @@ class TMDBService(
 							title = "${seriesDetails.name} Season ${seasonDetails.seasonNumber}",
 							overview = overview,
 							releaseDate = parseDate(seasonDetails.airDate),
+							mediaType = Production.MediaType.TV,
 							poster = getPosterUrl(seasonDetails.posterPath)
 						)
 						productions.add(production)
@@ -167,6 +169,7 @@ class TMDBService(
 						title = seriesDetails.name,
 						overview = overview,
 						releaseDate = parseDate(seasonDetails.airDate),
+						mediaType = Production.MediaType.TV,
 						poster = getPosterUrl(seasonDetails.posterPath)
 					)
 					productions.add(production)


### PR DESCRIPTION
Adds a property named `mediaType` for the `Production` entity. This property specifies if a production is either a movie ("MOVIE") or TV show ("TV").