### PR TITLE
Use snake case property naming strategy

### DIFF
--- a/src/main/kotlin/app/umcu/api/features/error/Error.kt
+++ b/src/main/kotlin/app/umcu/api/features/error/Error.kt
@@ -27,8 +27,11 @@
 
 package app.umcu.api.features.error
 
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import org.springframework.http.HttpStatus
 
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
 data class Error(
 	val status: Int, val reason: String
 ) {

--- a/src/main/kotlin/app/umcu/api/features/productions/model/Production.kt
+++ b/src/main/kotlin/app/umcu/api/features/productions/model/Production.kt
@@ -28,12 +28,15 @@
 package app.umcu.api.features.productions.model
 
 import app.umcu.api.extensions.toSlug
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
 import jakarta.persistence.*
 import java.time.LocalDate
 
 @Suppress("unused")
 @Entity
 @Table(name = "productions", uniqueConstraints = [UniqueConstraint(columnNames = ["slug"])])
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
 data class Production(
 	@Column(nullable = false) var tmdbId: Int? = null,
 	@Column(columnDefinition = "TEXT", nullable = false) var title: String? = null,


### PR DESCRIPTION
This causes the JSON properties from the API response(s) to be formatted as snake_case rather than camelCase.

For example:

```json
{
    "tmdbId": 1726,
    "title": "Iron Man"
    "releaseDate": "2008-05-02"
  }
  ```

would become:

```json
{
    "tmdb_id": 1726,
    "title": "Iron Man"
    "release_date": "2008-05-02"
  }
  ```